### PR TITLE
US13586 Lit 2 Migration - Phase 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@babel/eslint-parser": "^7",
     "@brightspace-ui/stylelint-config": "^0.3",
-    "@open-wc/testing": "^2",
+    "@open-wc/testing": "^3",
     "@web/dev-server": "^0.1",
     "@web/test-runner": "^0.13",
     "@web/test-runner-saucelabs": "^0.6",
@@ -43,7 +43,7 @@
     "stylelint": "^14"
   },
   "dependencies": {
-    "@brightspace-ui/core": "^1",
-    "lit-element": "^2"
+    "@brightspace-ui/core": "^2",
+    "lit-element": "^3"
   }
 }


### PR DESCRIPTION
[US13586](https://rally1.rallydev.com/#/431372673576ud/iterationstatus?detail=%2Fuserstory%2F623965078737)
**NO CHANGES WERE NECESSARY FOR PHASE 1.**

This PR makes the breaking changes required to update to Lit 2 (`lit-html` 2 and `lit-element` 3). The Lit 2 upgrade will be a coordinated effort, so **this PR should not merge at this time**. 

Breaking change checklist:  
- [x] Update `lit-html` -> `^2`, `lit-element` -> `^3`, `open-wc/testing` -> `^3` (if used) 
- [x] `createRenderRoot` usages -> move from LitElement to ReactiveElement  
- [x] Remove Dependabot Lit rules 
- [x] Bump any dependencies to their Lit 2 versions 
- [x] Remove any manual lifecycle calls to Lit 1 reactive controllers 
- [x] Backwards-compatible changes merged: <Your GitHub PR link> 

Renamed API's: 
- [x] `UpdatingElement` -> `ReactiveElement` 
- [x] `@internalProperty` -> `@state` (we don't use TypeScript decorators) 
- [x] `static getStyles()` -> `static finalizeStyles(styles)` 
- [x] `_getUpdateComplete()` -> `getUpdateComplete()` 
- [x] `NodePart` -> `ChildPart` 

Testing checklist:  
- [x] CI/ unit tests pass 
- [x] Local testing on demo pages 
- [x] Testing component in the LMS -- test in Custom ADS Scheduler story instead

For more information on the Lit 2 upgrade, visit https://lit.dev/docs/releases/upgrade/ or contact team Gaudi. 