### PR TITLE
Switch incremental-release to point to main version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
           cache: 'npm'
       - name: Incremental Release
         id: incremental-release
-        uses: BrightspaceUI/actions/incremental-release@master
+        uses: BrightspaceUI/actions/incremental-release@main
         with:
           DEFAULT_INCREMENT: patch
           GITHUB_TOKEN: ${{ secrets.D2L_GITHUB_TOKEN }}


### PR DESCRIPTION
We updated `incremental-release` to work with the new fine-grained PAT version of `D2L_GITHUB_TOKEN`, but we only did so on the `main` branch: https://github.com/BrightspaceUI/actions/pull/103
We want to delete the `master` version anyways, so we're switching everyone over to use that.