### PR TITLE
fix lit dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
   },
   "dependencies": {
     "@brightspace-ui/core": "^2",
-    "lit-element": "^3"
+    "lit": "^2"
   }
 }

--- a/role-item.js
+++ b/role-item.js
@@ -1,4 +1,4 @@
-import { css, html, LitElement } from 'lit-element/lit-element.js';
+import { css, html, LitElement } from 'lit';
 import { checkboxStyles } from '@brightspace-ui/core/components/inputs/input-checkbox.js';
 
 class RoleItem extends LitElement {

--- a/role-selector.js
+++ b/role-selector.js
@@ -1,7 +1,7 @@
 import '@brightspace-ui/core/components/dialog/dialog.js';
 import '@brightspace-ui/core/components/button/button.js';
 import '@brightspace-ui/core/components/colors/colors.js';
-import { css, html, LitElement } from 'lit-element/lit-element.js';
+import { css, html, LitElement } from 'lit';
 import { checkboxStyles } from '@brightspace-ui/core/components/inputs/input-checkbox.js';
 import { inputLabelStyles } from '@brightspace-ui/core/components/inputs/input-label-styles';
 import { LocalizeMixin } from './mixins/localize-mixin.js';


### PR DESCRIPTION
This isn't a prerequisite for upgrading to Lit 3 next year, but cleaning up the warnings would be nice. Both `lit-element` and `lit-html` have been rolled into `lit` for quite some time.